### PR TITLE
feat: implement roadmap improvements — soft deletes, search, DB trans…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,37 +23,45 @@ php artisan test --filter=<TestName>   # Run a single test or test class
 
 ## Architecture
 
-**Laravel 12 + Livewire 3** application — no separate API or SPA. All interactivity is handled server-side via Livewire components.
+**Laravel 12 + Livewire 3** application — no separate API or SPA. All interactivity is handled server-side via Livewire components. There is only one traditional HTTP controller (`Auth/VerifyEmailController`); everything else is Livewire.
 
 ### Core Models (all use UUID primary keys, all scoped to `User`)
-- **Transaction** — Income or expense record; type enum `income|expense`, state enum `paid|pending`; optional `expected_payment_date` for pending payments
-- **Category** — User-defined category with auto-generated slug; cannot be deleted if transactions exist
-- **Obligation** — Recurring monthly billing; can auto-generate transactions; toggleable active/inactive
+- **Transaction** — Income or expense record; type enum `income|expense`, state enum `paid|pending`; optional `expected_payment_date` for pending payments; has accessor `getIsPaymentFutureAttribute()` used for due-date highlighting
+- **Category** — User-defined category with auto-generated slug; `is_active` boolean; cannot be deleted if transactions exist (enforced via DB constraint)
+- **Obligation** — Recurring monthly billing with `limit_day`; can auto-generate transactions; toggleable active/inactive
+
+### Authorization
+All three models have Policies (`CategoryPolicy`, `TransactionPolicy`, `ObligationPolicy`) that enforce `user_id` ownership for `update` and `delete` operations. Data isolation is tested in `tests/Feature/*/` `*AuthorizationTest` and `*DataIsolationTest` files.
 
 ### Livewire Component Pattern
-Each feature area has components under `app/Livewire/<Feature>/`:
-- `Index` — list view with filtering
-- `Create` / `Update` — modal-based forms using Livewire Form Objects (`app/Livewire/Forms/`)
-- `Filters` — reactive search/filter panel
+Components live under `app/Livewire/<Feature>/`. The pattern varies by feature:
+- **Transactions**: `Create`, `Update`, `Index`, `Filters`, `PendingTransactions`
+- **Categories**: flat naming — `CategoryCreate`, `CategoryEdit`, `CategoryIndex` (no subfolder nesting)
+- **Obligations**: `MonthlyBillings` (single component)
+- **Metrics**: `Grid` (dashboard)
+- **Settings**: `Profile`, `Password`, `Appearance`, `DeleteUserForm`
 
-Form objects (e.g. `TransactionForm`, `CategoryForm`, `ObligationForm`) use `#[Validate]` attributes and handle both `store()` and `update()` logic.
+Form objects in `app/Livewire/Forms/` (`TransactionForm`, `CategoryForm`, `ObligationForm`) use `#[Validate]` attributes and handle both `store()` and `update()` logic.
 
 ### Feature Areas
-- **Transactions** (`/transaction/*`) — Create, edit, list by month, filter, view pending payments with due-date highlighting
-- **Categories** (`/category`) — CRUD with slug management
+- **Transactions** (`/transaction`, `/transaction/{id}/edit`) — Create, edit, list by month, filter, view pending payments with due-date highlighting (`/pending-transactions`)
+- **Categories** (`/category`, `/category/{id}/edit`) — CRUD with slug management and active/inactive toggle
 - **Obligations** (`/obligation`) — Monthly billings that can spawn transactions
-- **Dashboard** (`/dashboard`) — Metrics grid (`app/Livewire/Metrics/Grid`)
+- **Dashboard** (`/dashboard`) — Metrics grid; requires `auth` + `verified` middleware
 - **Settings** (`/settings/*`) — Profile, password, appearance, account deletion
-- **Auth** (`/routes/auth.php`) — Livewire-based login, register, password reset, email verification
+- **Auth** (`routes/auth.php`) — Livewire-based login, register, password reset, email verification
 
 ### Frontend
 - **Blade templates** in `resources/views/`, with `layouts/app.blade.php` as the main shell
 - **Flux** UI component library (pre-built components accessed as `<flux:*>`)
 - **Tailwind CSS v4** via Vite plugin
 - **flatpickr** for date pickers
+- **PWA** support via `silviolleite/laravelpwa` (installable, offline-capable)
+- **Livewire Volt** available for single-file components (`livewire/volt`)
 
 ### Testing Setup
 - Uses **Pest PHP v3**
 - In-memory SQLite database (configured in `phpunit.xml`)
 - Feature tests live in `tests/Feature/`, unit tests in `tests/Unit/`
-- Model factories available for all core models
+- Model factories available for all core models; `TransactionFactory` has a `.pending()` state
+- Test focus areas: authorization/policy enforcement, data isolation between users, Livewire component interactions

--- a/app/Livewire/Category/CategoryIndex.php
+++ b/app/Livewire/Category/CategoryIndex.php
@@ -34,7 +34,7 @@ class CategoryIndex extends Component
 
         $category->delete();
 
-        session()->flash('message', 'El registo ha sido eliminado del sistema.');
+        session()->flash('message', 'El registro ha sido eliminado del sistema.');
 
         $this->redirect(route('category.index'), navigate: true);
     }

--- a/app/Livewire/Forms/ObligationForm.php
+++ b/app/Livewire/Forms/ObligationForm.php
@@ -6,12 +6,15 @@ use App\Models\Category;
 use App\Models\Obligation;
 use App\Models\Transaction;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Livewire\Form;
 
 class ObligationForm extends Form
 {
+    private const OBLIGATIONS_CATEGORY_SLUG = 'obligaciones-mensuales';
+
     public ?Obligation $obligation = null;
 
     public string $name = '';
@@ -55,20 +58,22 @@ class ObligationForm extends Form
     {
         $this->validate();
 
-        $category = $this->resolveObligationsCategory();
-        $oldName  = $this->obligation->name;
+        DB::transaction(function () {
+            $category = $this->resolveObligationsCategory();
+            $oldName  = $this->obligation->name;
 
-        $this->obligation->update($this->all());
+            $this->obligation->update($this->all());
 
-        Transaction::where('user_id', auth()->id())
-            ->where('category_id', $category->id)
-            ->where('state', 'pending')
-            ->where('description', $oldName)
-            ->update([
-                'amount'                => $this->amount,
-                'description'           => $this->name,
-                'expected_payment_date' => Carbon::today()->setDay($this->limit_day),
-            ]);
+            Transaction::where('user_id', auth()->id())
+                ->where('category_id', $category->id)
+                ->where('state', 'pending')
+                ->where('description', $oldName)
+                ->update([
+                    'amount'                => $this->amount,
+                    'description'           => $this->name,
+                    'expected_payment_date' => Carbon::today()->setDay($this->limit_day),
+                ]);
+        });
     }
 
     public function createTransactions(Obligation $obligation): void
@@ -100,7 +105,7 @@ class ObligationForm extends Form
 
     public function removeTransactions(Obligation $obligation): void
     {
-        $category = Category::where('slug', 'obligaciones-mensuales')
+        $category = Category::where('slug', self::OBLIGATIONS_CATEGORY_SLUG)
             ->where('user_id', auth()->id())
             ->first();
 
@@ -119,7 +124,7 @@ class ObligationForm extends Form
     private function resolveObligationsCategory(): Category
     {
         return Category::firstOrCreate(
-            ['slug' => 'obligaciones-mensuales', 'user_id' => auth()->id()],
+            ['slug' => self::OBLIGATIONS_CATEGORY_SLUG, 'user_id' => auth()->id()],
             [
                 'category'    => 'Obligaciones Mensuales',
                 'description' => 'Pagos fijos mensuales',

--- a/app/Livewire/Forms/TransactionForm.php
+++ b/app/Livewire/Forms/TransactionForm.php
@@ -22,7 +22,7 @@ class TransactionForm extends Form
     {
         return [
             'type'                  => 'required|in:income,expense',
-            'amount'                => 'required|min:0|numeric',
+            'amount'                => 'required|numeric|min:0.01',
             'description'           => 'required|string|max:255',
             'expected_payment_date' => 'nullable',
             'date'                  => 'required|before_or_equal:today',

--- a/app/Livewire/Obligations/MonthlyBillings.php
+++ b/app/Livewire/Obligations/MonthlyBillings.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Obligations;
 
 use App\Livewire\Forms\ObligationForm;
 use App\Models\Obligation;
+use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 
 class MonthlyBillings extends Component
@@ -35,8 +36,10 @@ class MonthlyBillings extends Component
 
     public function save()
     {
-        $obligation = $this->form->store();
-        $this->form->createTransactions($obligation);
+        DB::transaction(function () {
+            $obligation = $this->form->store();
+            $this->form->createTransactions($obligation);
+        });
         $this->obligationModalIsOpen = false;
         session()->flash('message', 'Se ha creado una nueva obligación y sus cuentas por pagar cada mes.');
         $this->form->reset();
@@ -55,19 +58,26 @@ class MonthlyBillings extends Component
     {
         $this->authorize('update', $obligation);
         $isActive = $obligation->is_active;
-        $isActive
-            ? $this->form->removeTransactions($obligation)
-            : $this->form->createTransactions($obligation);
 
-        $obligation->update(['is_active' => !$isActive]);
+        DB::transaction(function () use ($obligation, $isActive) {
+            $isActive
+                ? $this->form->removeTransactions($obligation)
+                : $this->form->createTransactions($obligation);
+            $obligation->update(['is_active' => !$isActive]);
+        });
+
         session()->flash('message', 'Se ha ' . ($isActive ? 'desactivado' : 'activado') . ' tu obligación.');
     }
 
     public function delete(Obligation $obligation)
     {
         $this->authorize('delete', $obligation);
-        $this->form->removeTransactions($obligation);
-        $obligation->delete();
+
+        DB::transaction(function () use ($obligation) {
+            $this->form->removeTransactions($obligation);
+            $obligation->delete();
+        });
+
         session()->flash('message', 'Se ha eliminado la obligación y tus cuentas por pagar relacionadas.');
     }
     

--- a/app/Livewire/Transactions/Filters.php
+++ b/app/Livewire/Transactions/Filters.php
@@ -24,6 +24,7 @@ class Filters extends Component
     public float $expenses = 0;
 
     public string $showType = 'all';
+    public string $search = '';
 
     public function mount(): void
     {
@@ -53,12 +54,17 @@ class Filters extends Component
         $this->resetPage();
     }
 
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
     public function delete(Transaction $transaction)
     {
         $this->authorize('delete', $transaction);
         $transaction->delete();
 
-        session()->flash('message', 'El registo ha sido eliminado del sistema.');
+        session()->flash('message', 'El registro ha sido eliminado del sistema.');
     }
 
     public function render(): View
@@ -88,6 +94,9 @@ class Filters extends Component
 
         if ($this->showType !== 'all')
             $query->where('type', $this->showType);
+
+        if ($this->search !== '')
+            $query->where('description', 'like', '%' . $this->search . '%');
 
         $totals = (clone $query)
             ->selectRaw('

--- a/app/Livewire/Transactions/Index.php
+++ b/app/Livewire/Transactions/Index.php
@@ -12,7 +12,8 @@ class Index extends Component
     public function mount()
     {
         $user = auth()->id();
-        $this->transactions = Transaction::take(8)
+        $this->transactions = Transaction::with('category')
+            ->take(8)
             ->where('user_id', $user)
             ->where('state', 'paid')
             ->where('date', '>=', now()->startOfMonth())
@@ -26,7 +27,7 @@ class Index extends Component
         $this->authorize('delete', $transaction);
         $transaction->delete();
 
-        session()->flash('message', 'El registo ha sido eliminado del sistema.');
+        session()->flash('message', 'El registro ha sido eliminado del sistema.');
     }
 
     public function render()

--- a/app/Livewire/Transactions/PendingTransactions.php
+++ b/app/Livewire/Transactions/PendingTransactions.php
@@ -41,7 +41,7 @@ class PendingTransactions extends Component
         $this->authorize('delete', $transaction);
         $transaction->delete();
 
-        session()->flash('message', 'El registo ha sido eliminado del sistema.');
+        session()->flash('message', 'El registro ha sido eliminado del sistema.');
     }
 
     public function render()

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -6,10 +6,11 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Transaction extends Model
 {
-    use HasFactory, HasUuids;
+    use HasFactory, HasUuids, SoftDeletes;
 
     protected $fillable = ['type', 'amount', 'description', 'state', 'expected_payment_date', 'date', 'user_id', 'category_id'];
 

--- a/database/migrations/2026_03_31_120000_add_soft_deletes_to_transactions_table.php
+++ b/database/migrations/2026_03_31_120000_add_soft_deletes_to_transactions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/resources/views/components/app/stats-filter-bar.blade.php
+++ b/resources/views/components/app/stats-filter-bar.blade.php
@@ -60,6 +60,15 @@
                 </div>
                 <!-- Dialog Body -->
                 <div class="px-4 py-8 space-y-6">
+                    <div class="relative flex w-full max-w-xs flex-col gap-1 text-on-surface dark:text-on-surface-dark">
+                        <label for="search" class="w-fit pl-0.5 text-sm">Buscar</label>
+                        <input id="search"
+                               type="text"
+                               wire:model.live.debounce.300ms="search"
+                               placeholder="Buscar por descripción..."
+                               class="w-full rounded-radius border border-outline bg-surface-alt px-4 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:border-outline-dark dark:bg-surface-dark-alt/50 dark:focus-visible:outline-primary-dark"/>
+                    </div>
+
                     <div
                         class="relative flex items-center w-full max-w-xs flex-col gap-1 text-on-surface dark:text-on-surface-dark">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"

--- a/tests/Feature/Obligations/ObligationBehaviorTest.php
+++ b/tests/Feature/Obligations/ObligationBehaviorTest.php
@@ -36,7 +36,7 @@ test('deleting an obligation removes its pending transactions', function () {
         ->assertHasNoErrors();
 
     $this->assertDatabaseMissing('obligations', ['id' => $obligation->id]);
-    $this->assertDatabaseMissing('transactions', [
+    $this->assertSoftDeleted('transactions', [
         'user_id'     => $user->id,
         'description' => 'Alquiler',
         'state'       => 'pending',
@@ -64,7 +64,7 @@ test('deactivating an obligation removes its pending transactions', function () 
         ->assertHasNoErrors();
 
     $this->assertDatabaseHas('obligations', ['id' => $obligation->id, 'is_active' => false]);
-    $this->assertDatabaseMissing('transactions', [
+    $this->assertSoftDeleted('transactions', [
         'user_id'     => $user->id,
         'description' => 'Seguro',
         'state'       => 'pending',

--- a/tests/Feature/Transactions/TransactionAuthorizationTest.php
+++ b/tests/Feature/Transactions/TransactionAuthorizationTest.php
@@ -61,7 +61,7 @@ test('owner can delete transaction from index', function () {
         ->call('delete', $transaction->id)
         ->assertHasNoErrors();
 
-    $this->assertDatabaseMissing('transactions', ['id' => $transaction->id]);
+    $this->assertSoftDeleted('transactions', ['id' => $transaction->id]);
 });
 
 test('other user cannot delete transaction from index', function () {
@@ -93,7 +93,7 @@ test('owner can delete transaction from filters', function () {
         ->call('delete', $transaction->id)
         ->assertHasNoErrors();
 
-    $this->assertDatabaseMissing('transactions', ['id' => $transaction->id]);
+    $this->assertSoftDeleted('transactions', ['id' => $transaction->id]);
 });
 
 test('other user cannot delete transaction from filters', function () {


### PR DESCRIPTION
…actions, N+1 fix

- Wrap ObligationForm::update() and MonthlyBillings save/changeStatus/delete in DB::transaction() to prevent orphaned records on failure
- Add SoftDeletes to Transaction model with migration; update tests to assertSoftDeleted
- Add eager loading with('category') on Transactions\Index to eliminate N+1
- Add description search (live, debounced) to Filters component and modal UI
- Extract hardcoded 'obligaciones-mensuales' slug to OBLIGATIONS_CATEGORY_SLUG constant
- Fix amount validation: min:0 → min:0.01 to prevent zero-value transactions
- Fix typo 'registo' → 'registro' in flash messages across 4 components
- Update CLAUDE.md with accurate component naming and architecture details