### PR TITLE
fix(auth): show real errors on password reset form

### DIFF
--- a/app/Livewire/Auth/ForgotPassword.php
+++ b/app/Livewire/Auth/ForgotPassword.php
@@ -20,8 +20,13 @@ class ForgotPassword extends Component
             'email' => ['required', 'string', 'email'],
         ]);
 
-        Password::sendResetLink($this->only('email'));
+        $status = Password::sendResetLink($this->only('email'));
 
-        session()->flash('status', __('Se enviará un enlace de restablecimiento si la cuenta existe.'));
+        if ($status !== Password::RESET_LINK_SENT) {
+            $this->addError('email', __($status));
+            return;
+        }
+
+        session()->flash('status', __($status));
     }
 }

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -14,7 +14,11 @@
             required
             autofocus
             placeholder="email@example.com"
+            :invalid="$errors->has('email')"
         />
+        @error('email')
+            <flux:error>{{ $message }}</flux:error>
+        @enderror
 
         <flux:button variant="primary" type="submit"
                      class="w-full">{{ __('Enlace de restablecimiento de contraseña') }}</flux:button>


### PR DESCRIPTION
Password::sendResetLink() result was being ignored — failures (SMTP misconfigured, rate limit, etc.) were silently swallowed. Now surfaces the exact error on the email field and only flashes success when the link was actually sent.