### PR TITLE
fix(filters): add default branch to match on selectedTab

### DIFF
--- a/app/Livewire/Transactions/Filters.php
+++ b/app/Livewire/Transactions/Filters.php
@@ -15,20 +15,26 @@ class Filters extends Component
     use WithPagination;
 
     public string $selectedTab = 'days';
+
     public int $selectedMonth;
+
     public int $selectedYear;
 
     public Collection $categories;
-    public string|null $selectedCategory = null;
+
+    public ?string $selectedCategory = null;
+
     public float $incomes = 0;
+
     public float $expenses = 0;
 
     public string $showType = 'all';
+
     public string $search = '';
 
     public function mount(): void
     {
-        $this->selectedYear  = now()->year;
+        $this->selectedYear = now()->year;
         $this->selectedMonth = now()->month;
         $this->latestDays(7);
         $this->categories = Category::where('user_id', auth()->id())->get();
@@ -78,25 +84,33 @@ class Filters extends Component
 
             'current-month' => $query
                 ->where('date', '>=', Carbon::create($this->selectedYear, now()->month, 1))
-                ->where('date', '<',  Carbon::create($this->selectedYear, now()->month, 1)->addMonthNoOverflow()),
+                ->where('date', '<', Carbon::create($this->selectedYear, now()->month, 1)->addMonthNoOverflow()),
 
             'previous-month' => $query
                 ->where('date', '>=', Carbon::create($this->selectedYear, now()->subMonthNoOverflow()->month, 1))
-                ->where('date', '<',  Carbon::create($this->selectedYear, now()->subMonthNoOverflow()->month, 1)->addMonthNoOverflow()),
+                ->where('date', '<', Carbon::create($this->selectedYear, now()->subMonthNoOverflow()->month, 1)->addMonthNoOverflow()),
 
             'historical' => $query
                 ->where('date', '>=', Carbon::create($this->selectedYear, $this->selectedMonth, 1))
-                ->where('date', '<',  Carbon::create($this->selectedYear, $this->selectedMonth, 1)->addMonthNoOverflow()),
+                ->where('date', '<', Carbon::create($this->selectedYear, $this->selectedMonth, 1)->addMonthNoOverflow()),
+
+            // Defensive fallback: unexpected values (client tampering, stale state,
+            // regression adding a UI tab without a branch here) fall back to the most
+            // restrictive filter — 7 days — which matches the default set by mount().
+            default => $query->where('date', '>=', now()->subDays(7)),
         };
 
-        if ($this->selectedCategory && $this->selectedCategory !== 'all')
+        if ($this->selectedCategory && $this->selectedCategory !== 'all') {
             $query->where('category_id', $this->selectedCategory);
+        }
 
-        if ($this->showType !== 'all')
+        if ($this->showType !== 'all') {
             $query->where('type', $this->showType);
+        }
 
-        if ($this->search !== '')
-            $query->where('description', 'like', '%' . $this->search . '%');
+        if ($this->search !== '') {
+            $query->where('description', 'like', '%'.$this->search.'%');
+        }
 
         $totals = (clone $query)
             ->selectRaw('
@@ -105,7 +119,7 @@ class Filters extends Component
             ')
             ->first();
 
-        $this->incomes  = $totals->total_income  ?? 0;
+        $this->incomes = $totals->total_income ?? 0;
         $this->expenses = $totals->total_expense ?? 0;
 
         $transactions = $query

--- a/tests/Feature/Transactions/TransactionFiltersTest.php
+++ b/tests/Feature/Transactions/TransactionFiltersTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Livewire\Transactions\Filters;
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use Livewire\Livewire;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+// --- Invariant: Filters::render() must not throw UnhandledMatchError
+//     when selectedTab holds an unexpected value (client tampering,
+//     regression of code, stale state). ---
+
+test('unknown selectedTab value does not throw 500 in render', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Filters::class)
+        ->set('selectedTab', 'unknown-tab-value')
+        ->assertHasNoErrors()
+        ->assertOk();
+});
+
+test('empty selectedTab value does not throw 500 in render', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Filters::class)
+        ->set('selectedTab', '')
+        ->assertHasNoErrors()
+        ->assertOk();
+});
+
+// --- Invariant: fallback path must preserve tenant isolation.
+//     A broken default branch could silently drop the user_id filter. ---
+
+test('fallback on unknown selectedTab preserves tenant isolation', function () {
+    $userA = User::factory()->create();
+    $userB = User::factory()->create();
+
+    $categoryB = Category::factory()->for($userB)->create();
+
+    Transaction::factory()
+        ->for($userB)
+        ->for($categoryB)
+        ->create([
+            'type' => 'income',
+            'amount' => 9999,
+            'state' => 'paid',
+            'date' => now(),
+            'description' => 'secret-of-b',
+        ]);
+
+    $component = Livewire::actingAs($userA)
+        ->test(Filters::class)
+        ->set('selectedTab', 'foo');
+
+    expect((float) $component->get('incomes'))->toBe(0.0);
+    expect((float) $component->get('expenses'))->toBe(0.0);
+    $component->assertDontSee('secret-of-b');
+});
+
+// --- Invariant: fallback must not broaden scope beyond the most restrictive
+//     legitimate tab (7 days). Returning all-history would leak older data
+//     the user never requested. ---
+
+test('fallback on unknown selectedTab does not broaden scope beyond 7 days', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create([
+            'type' => 'income',
+            'amount' => 100,
+            'state' => 'paid',
+            'date' => now()->subDays(3),
+            'description' => 'recent-tx',
+        ]);
+
+    Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create([
+            'type' => 'income',
+            'amount' => 500,
+            'state' => 'paid',
+            'date' => now()->subDays(30),
+            'description' => 'old-tx-outside-window',
+        ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(Filters::class)
+        ->set('selectedTab', 'unknown');
+
+    expect((float) $component->get('incomes'))->toBe(100.0);
+    $component->assertSee('recent-tx')
+        ->assertDontSee('old-tx-outside-window');
+});


### PR DESCRIPTION
## Summary

- `Filters::render()` tiraba `UnhandledMatchError` (HTTP 500) si `selectedTab` recibía un valor inesperado (tampering de cliente, regresión al agregar un tab sin rama, estado stale).
- Fallback al filtro más restrictivo legítimo — últimos 7 días — coincidente con el default establecido por `mount()`.
- 4 tests adversariales nuevos: valor desconocido, string vacío, preservación de aislamiento tenant bajo fallback, no-ampliación de scope más allá de 7 días.
- Pint aplicó ajustes cosméticos sobre el archivo tocado (separación de atributos, llaves en `if` de una línea, `?string`).

## Test plan

- [x] 4 tests nuevos en `tests/Feature/Transactions/TransactionFiltersTest.php` fallan antes del fix con `UnhandledMatchError`; verdes después.
- [x] Suite completa: **76/76 passed** (155 assertions).

Corresponde al PR #1 de la Fase 0 del roadmap de refactor (fix de bugs silenciosos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)