### PR TITLE
test(categories): pin DB-level FK behavior on category deletion

### DIFF
--- a/tests/Feature/Categories/CategoryDeletionTest.php
+++ b/tests/Feature/Categories/CategoryDeletionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+// --- Invariant: DB-level foreign key integrity.
+//     The PHP guard in CategoryIndex::delete() is a UX convenience; the real
+//     protection against orphan transactions is the FK on transactions.category_id.
+//     These tests pin the DB-level behavior so that a refactor removing the
+//     guard, a migration regression to CASCADE, or a framework default change
+//     is caught immediately. ---
+
+test('database rejects deleting a category with a paid transaction referencing it', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+    Transaction::factory()->for($user)->for($category)->create(['state' => 'paid']);
+
+    expect(fn () => $category->delete())->toThrow(QueryException::class);
+
+    $this->assertDatabaseHas('categories', ['id' => $category->id]);
+});
+
+test('database rejects deleting a category with a pending transaction referencing it', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+    Transaction::factory()->for($user)->for($category)->pending()->create();
+
+    expect(fn () => $category->delete())->toThrow(QueryException::class);
+
+    $this->assertDatabaseHas('categories', ['id' => $category->id]);
+});
+
+// Soft delete is an application-level concept; the FK constraint still sees
+// the row as present. This is intentional — if we ever want "soft-deleted
+// transactions release their category FK", that needs a dedicated purge path.
+test('database rejects deleting a category even when its transactions are soft-deleted', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+    $transaction = Transaction::factory()->for($user)->for($category)->create();
+
+    $transaction->delete();
+    $this->assertSoftDeleted('transactions', ['id' => $transaction->id]);
+
+    expect(fn () => $category->delete())->toThrow(QueryException::class);
+
+    $this->assertDatabaseHas('categories', ['id' => $category->id]);
+});
+
+test('category with no transactions can be deleted directly via eloquent', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    $category->delete();
+
+    $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+});


### PR DESCRIPTION
## Summary

PR puramente de tests. Cero cambios en código de producción.

Documenta la invariante de integridad referencial que protege `transactions.category_id`:

- El guard PHP en `CategoryIndex::delete()` es conveniencia UX.
- La protección real contra transacciones huérfanas es la FK a nivel de DB.
- Sin estos tests, un refactor que remueva el guard, una migration que pase la FK a CASCADE, o un cambio de default en `constrained()` en una futura versión de Laravel, pasaría desapercibido.

## Invariantes cubiertas

1. DB rechaza `$category->delete()` si existe transacción **paid** referenciándola.
2. Ídem con transacción **pending**.
3. Ídem aun cuando la transacción está **soft-deleted** — soft delete es app-level, la FK sigue viendo la fila. Documenta un borde intencional: si alguna vez queremos "soft delete libera FK", necesita un purge path dedicado, no esperanza.
4. Happy path — categoría sin transacciones se elimina directo.

## Test plan

- [x] 4 tests nuevos en `tests/Feature/Categories/CategoryDeletionTest.php`.
- [x] Suite completa: **86/86 passed** (181 assertions).

Corresponde al PR #3 de la Fase 0 del roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)