### PR TITLE
refactor(filters): drop unused $days parameter from latestDays()

### DIFF
--- a/app/Livewire/Transactions/Filters.php
+++ b/app/Livewire/Transactions/Filters.php
@@ -36,11 +36,11 @@ class Filters extends Component
     {
         $this->selectedYear = now()->year;
         $this->selectedMonth = now()->month;
-        $this->latestDays(7);
+        $this->latestDays();
         $this->categories = Category::where('user_id', auth()->id())->get();
     }
 
-    public function latestDays($days): void
+    public function latestDays(): void
     {
         $this->selectedTab = 'days';
     }

--- a/resources/views/livewire/transactions/filters.blade.php
+++ b/resources/views/livewire/transactions/filters.blade.php
@@ -2,7 +2,7 @@
     <div x-on:keydown.right.prevent="$focus.wrap().next()" x-on:keydown.left.prevent="$focus.wrap().previous()"
          class="flex flex-col sm:flex-row gap-2 border-b border-outline dark:border-outline-dark" role="tablist"
          aria-label="tab options">
-        <button x-on:click="$wire.latestDays(7)" x-bind:aria-selected="selectedTab === 'days'"
+        <button x-on:click="$wire.latestDays()" x-bind:aria-selected="selectedTab === 'days'"
                 x-bind:tabindex="selectedTab === 'days' ? '0' : '-1'"
                 x-bind:class="selectedTab === 'days' ? ' font-bold text-secondary border-b-2 dark:border-primary-dark dark:text-primary-dark' : 'text-on-surface font-medium dark:text-on-surface-dark dark:hover:border-b-outline-dark-strong dark:hover:text-on-surface-dark-strong hover:border-b-2 hover:border-b-outline-strong hover:text-on-surface-strong'"
                 class="h-min px-3 py-2 sm:px-4 sm:py-4 text-xs sm:text-sm {{ $selectedTab === 'days' ? 'bg-gradient-to-t from-neutral-200 dark:from-neutral-800 shadow shadow-gray-400 dark:shadow-gray-600' : '' }}"

--- a/tests/Feature/Transactions/TransactionFiltersTest.php
+++ b/tests/Feature/Transactions/TransactionFiltersTest.php
@@ -99,3 +99,45 @@ test('fallback on unknown selectedTab does not broaden scope beyond 7 days', fun
     $component->assertSee('recent-tx')
         ->assertDontSee('old-tx-outside-window');
 });
+
+// --- latestDays() tab wiring ---
+// Protects the days-tab behavior from drift while the unused $days parameter
+// is removed. The tab must continue to show only transactions within the last
+// 7 days, end-to-end.
+
+test('clicking the days tab filters the render to the last 7 days', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create([
+            'type' => 'income',
+            'amount' => 100,
+            'state' => 'paid',
+            'date' => now()->subDays(3),
+            'description' => 'within-7-days-window',
+        ]);
+
+    Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create([
+            'type' => 'income',
+            'amount' => 500,
+            'state' => 'paid',
+            'date' => now()->subDays(30),
+            'description' => 'outside-7-days-window',
+        ]);
+
+    $component = Livewire::actingAs($user)
+        ->test(Filters::class)
+        ->set('selectedTab', 'historical')
+        ->call('latestDays');
+
+    expect($component->get('selectedTab'))->toBe('days');
+    expect((float) $component->get('incomes'))->toBe(100.0);
+    $component->assertSee('within-7-days-window')
+        ->assertDontSee('outside-7-days-window');
+});


### PR DESCRIPTION
## Summary

- `Filters::latestDays($days)` recibía un argumento que el cuerpo ignoraba.
- Los 3 call sites siempre pasaban `7`. `render()` usaba `now()->subDays(7)` hardcodeado.
- Eliminar el parámetro en los 3 puntos (signature + `mount()` + botón Blade) es lossless.

## Decisión de producto

Opción **B** del roadmap original: borrar el parámetro y dejar "últimos 7 días" fijo. Si en el futuro se quiere exponer 7/15/30 como tabs, es un feature aparte que no arrastra esta deuda.

## Test plan

- [x] Test nuevo end-to-end: al llamar `latestDays`, el render filtra a últimos 7 días. Crear tx a 3 días + tx a 30 días, verifico que solo se ve la reciente.
- [x] Pre-fix: falla con `BindingResolutionException: Unable to resolve dependency [Parameter #0 <required> $days]` — justamente la razón del PR.
- [x] Post-fix: **87/87 passed** (185 assertions).

Corresponde al PR #4 de la Fase 0 del roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)