### PR TITLE
refactor: add TransactionType and TransactionState enums

### DIFF
--- a/app/Enums/TransactionState.php
+++ b/app/Enums/TransactionState.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum TransactionState: string
+{
+    case Paid = 'paid';
+    case Pending = 'pending';
+}

--- a/app/Enums/TransactionType.php
+++ b/app/Enums/TransactionType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum TransactionType: string
+{
+    case Income = 'income';
+    case Expense = 'expense';
+}

--- a/app/Livewire/Forms/CategoryForm.php
+++ b/app/Livewire/Forms/CategoryForm.php
@@ -10,9 +10,9 @@ class CategoryForm extends Form
 {
     public ?Category $categorySelected = null;
 
-    public string|null $category = '';
+    public ?string $category = '';
 
-    public string|null $description = '';
+    public ?string $description = '';
 
     public function rules(): array
     {
@@ -29,8 +29,8 @@ class CategoryForm extends Form
                 'nullable',
                 'string',
                 'min:5',
-                'max:255'
-            ]
+                'max:255',
+            ],
         ];
     }
 

--- a/app/Livewire/Forms/ObligationForm.php
+++ b/app/Livewire/Forms/ObligationForm.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire\Forms;
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use App\Models\Category;
 use App\Models\Obligation;
 use App\Models\Transaction;
@@ -71,7 +73,7 @@ class ObligationForm extends Form
 
             Transaction::where('user_id', auth()->id())
                 ->where('category_id', $category->id)
-                ->where('state', 'pending')
+                ->where('state', TransactionState::Pending)
                 ->where('description', $oldName)
                 ->update([
                     'amount' => $this->amount,
@@ -106,10 +108,10 @@ class ObligationForm extends Form
             // placing transactions in the wrong month.
             $rows[] = [
                 'id' => (string) Str::uuid(),
-                'type' => 'expense',
+                'type' => TransactionType::Expense->value,
                 'amount' => $obligation->amount,
                 'description' => $obligation->name,
-                'state' => 'pending',
+                'state' => TransactionState::Pending->value,
                 'expected_payment_date' => Carbon::create($year, $month, $obligation->limit_day),
                 'date' => Carbon::create($year, $month, 1),
                 'user_id' => auth()->id(),
@@ -136,7 +138,7 @@ class ObligationForm extends Form
 
         Transaction::where('user_id', auth()->id())
             ->where('category_id', $category->id)
-            ->where('state', 'pending')
+            ->where('state', TransactionState::Pending)
             ->where('description', $obligation->name)
             ->delete();
     }

--- a/app/Livewire/Forms/TransactionForm.php
+++ b/app/Livewire/Forms/TransactionForm.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire\Forms;
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use App\Models\Transaction;
 use Illuminate\Validation\Rule;
 use Livewire\Form;
@@ -11,23 +13,29 @@ class TransactionForm extends Form
     public ?Transaction $transaction;
 
     public $type;
+
     public $amount;
+
     public $description;
+
     public $state = true;
+
     public $expected_payment_date;
+
     public $category_id;
+
     public $date;
 
     public function rules(): array
     {
         return [
-            'type'                  => 'required|in:income,expense',
-            'amount'                => 'required|numeric|min:0.01',
-            'description'           => 'required|string|max:255',
+            'type' => ['required', Rule::enum(TransactionType::class)],
+            'amount' => 'required|numeric|min:0.01',
+            'description' => 'required|string|max:255',
             'expected_payment_date' => 'nullable',
-            'date'                  => 'required|before_or_equal:today',
+            'date' => 'required|before_or_equal:today',
             // Validates existence AND ownership — prevents assigning another user's category
-            'category_id'           => [
+            'category_id' => [
                 'required',
                 Rule::exists('categories', 'id')->where('user_id', auth()->id()),
             ],
@@ -37,12 +45,13 @@ class TransactionForm extends Form
     public function setTransaction(Transaction $transaction)
     {
         $this->transaction = $transaction;
-        $this->type = $transaction->type;
+        // Blade bindings expect the raw string value (e.g. 'income'), not the enum instance.
+        $this->type = $transaction->type->value;
         $this->amount = $transaction->amount;
         $this->description = $transaction->description;
         $this->date = $transaction->formatted_date;
         $this->category_id = $transaction->category_id;
-        $this->state = $transaction->state === 'paid';
+        $this->state = $transaction->isPaid();
         $this->expected_payment_date = $transaction->formatted_expected_payment_date;
     }
 
@@ -50,15 +59,15 @@ class TransactionForm extends Form
     {
         $validated = $this->validate();
         $validated['user_id'] = auth()->id();
-        $validated['state'] = $this->state ? 'paid' : 'pending';
+        $validated['state'] = $this->state ? TransactionState::Paid : TransactionState::Pending;
         Transaction::create($validated);
     }
 
     public function update()
     {
         $validated = $this->validate();
-        $validated['expected_payment_date'] = !blank($validated['expected_payment_date']) ? $validated['expected_payment_date'] : null;
-        $validated['state'] = $this->state ? 'paid' : 'pending';
+        $validated['expected_payment_date'] = ! blank($validated['expected_payment_date']) ? $validated['expected_payment_date'] : null;
+        $validated['state'] = $this->state ? TransactionState::Paid : TransactionState::Pending;
         $this->transaction->update($validated);
     }
 }

--- a/app/Livewire/Metrics/Grid.php
+++ b/app/Livewire/Metrics/Grid.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire\Metrics;
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use App\Models\Transaction;
 use Illuminate\View\View;
 use Livewire\Component;
@@ -9,11 +11,15 @@ use Livewire\Component;
 class Grid extends Component
 {
     public $total_income;
+
     public $total_expense;
+
     public $receivable_transactions;
+
     public $payable_transactions;
 
     public $modalIsOpen = false;
+
     public $modalType = null;
 
     public function openModal($type)
@@ -31,7 +37,7 @@ class Grid extends Component
     public function changeStatus(Transaction $transaction)
     {
         $this->authorize('update', $transaction);
-        $transaction->update(['state' => 'paid', 'expected_payment_date' => null]);
+        $transaction->update(['state' => TransactionState::Paid, 'expected_payment_date' => null]);
     }
 
     public function render(): View
@@ -41,18 +47,18 @@ class Grid extends Component
         // Pending transactions up to the end of the current month — one query,
         // partitioned in PHP to avoid a second round-trip.
         $allPending = (clone $base)
-            ->where('state', 'pending')
+            ->where('state', TransactionState::Pending)
             ->where('date', '<', now()->addMonth()->startOfMonth())
             ->orderBy('date')
             ->get();
 
-        $this->receivable_transactions = $allPending->where('type', 'income');
-        $this->payable_transactions    = $allPending->where('type', 'expense');
+        $this->receivable_transactions = $allPending->where('type', TransactionType::Income);
+        $this->payable_transactions = $allPending->where('type', TransactionType::Expense);
 
         // Current-month paid totals — single query with conditional aggregation
         // instead of two separate sum() calls.
         $totals = (clone $base)
-            ->where('state', 'paid')
+            ->where('state', TransactionState::Paid)
             ->where('date', '>=', now()->startOfMonth())
             ->where('date', '<', now()->addMonth()->startOfMonth())
             ->selectRaw('
@@ -61,7 +67,7 @@ class Grid extends Component
             ')
             ->first();
 
-        $this->total_income  = $totals->total_income  ?? 0;
+        $this->total_income = $totals->total_income ?? 0;
         $this->total_expense = $totals->total_expense ?? 0;
 
         return view('livewire.metrics.grid');

--- a/app/Livewire/Transactions/Create.php
+++ b/app/Livewire/Transactions/Create.php
@@ -9,6 +9,7 @@ use Livewire\Component;
 class Create extends Component
 {
     public TransactionForm $form;
+
     public $categories = [];
 
     public function mount()

--- a/app/Livewire/Transactions/Filters.php
+++ b/app/Livewire/Transactions/Filters.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire\Transactions;
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use App\Models\Category;
 use App\Models\Transaction;
 use Carbon\Carbon;
@@ -75,7 +77,7 @@ class Filters extends Component
 
     public function render(): View
     {
-        $query = Transaction::where('user_id', auth()->id())->where('state', 'paid');
+        $query = Transaction::where('user_id', auth()->id())->where('state', TransactionState::Paid);
 
         // Use explicit date ranges instead of MONTH()/YEAR() functions so MySQL
         // can perform a range scan on the (user_id, state, date) composite index.
@@ -105,7 +107,7 @@ class Filters extends Component
         }
 
         if ($this->showType !== 'all') {
-            $query->where('type', $this->showType);
+            $query->where('type', TransactionType::from($this->showType));
         }
 
         if ($this->search !== '') {

--- a/app/Livewire/Transactions/Index.php
+++ b/app/Livewire/Transactions/Index.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Transactions;
 
+use App\Enums\TransactionState;
 use App\Models\Transaction;
 use Livewire\Component;
 
@@ -15,7 +16,7 @@ class Index extends Component
         $this->transactions = Transaction::with('category')
             ->take(8)
             ->where('user_id', $user)
-            ->where('state', 'paid')
+            ->where('state', TransactionState::Paid)
             ->where('date', '>=', now()->startOfMonth())
             ->where('date', '<', now()->addMonth()->startOfMonth())
             ->orderBy('date', 'desc')

--- a/app/Livewire/Transactions/PendingTransactions.php
+++ b/app/Livewire/Transactions/PendingTransactions.php
@@ -2,6 +2,8 @@
 
 namespace App\Livewire\Transactions;
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use App\Models\Transaction;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
@@ -12,7 +14,9 @@ class PendingTransactions extends Component
     use WithPagination;
 
     public Collection $receivables;
+
     public Collection $payables;
+
     public string $selectedTab = 'all';
 
     public function selectAll()
@@ -33,7 +37,7 @@ class PendingTransactions extends Component
     public function changeStatus(Transaction $transaction)
     {
         $this->authorize('update', $transaction);
-        $transaction->update(['state' => 'paid', 'expected_payment_date' => null]);
+        $transaction->update(['state' => TransactionState::Paid, 'expected_payment_date' => null]);
     }
 
     public function delete(Transaction $transaction)
@@ -47,16 +51,16 @@ class PendingTransactions extends Component
     public function render()
     {
         $query = Transaction::where('user_id', auth()->id())
-            ->where('state', 'pending')
+            ->where('state', TransactionState::Pending)
             ->where('date', '<', now()->addMonth()->startOfMonth());
 
-        $this->receivables = (clone $query)->where('type', 'income')->get();
-        $this->payables    = (clone $query)->where('type', 'expense')->get();
+        $this->receivables = (clone $query)->where('type', TransactionType::Income)->get();
+        $this->payables = (clone $query)->where('type', TransactionType::Expense)->get();
 
         $query = match ($this->selectedTab) {
-            'all'        => $query,
-            'receivable' => $query->where('type', 'income'),
-            'payable'    => $query->where('type', 'expense'),
+            'all' => $query,
+            'receivable' => $query->where('type', TransactionType::Income),
+            'payable' => $query->where('type', TransactionType::Expense),
         };
 
         $transactions = $query

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -18,7 +20,29 @@ class Transaction extends Model
         'amount' => 'decimal:2',
         'date' => 'date',
         'expected_payment_date' => 'date',
+        'type' => TransactionType::class,
+        'state' => TransactionState::class,
     ];
+
+    public function isIncome(): bool
+    {
+        return $this->type === TransactionType::Income;
+    }
+
+    public function isExpense(): bool
+    {
+        return $this->type === TransactionType::Expense;
+    }
+
+    public function isPaid(): bool
+    {
+        return $this->state === TransactionState::Paid;
+    }
+
+    public function isPending(): bool
+    {
+        return $this->state === TransactionState::Pending;
+    }
 
     public function user(): BelongsTo
     {
@@ -42,7 +66,7 @@ class Transaction extends Model
 
     public function getIsPaymentFutureAttribute()
     {
-        if (!$this->expected_payment_date) {
+        if (! $this->expected_payment_date) {
             return null;
         }
 

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories;
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use App\Models\Category;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -16,10 +18,10 @@ class TransactionFactory extends Factory
         $user = User::factory()->create();
 
         return [
-            'type' => fake()->randomElement(['income', 'expense']),
+            'type' => fake()->randomElement(TransactionType::cases()),
             'amount' => fake()->randomFloat(2, 1, 10000),
             'description' => fake()->sentence(),
-            'state' => 'paid',
+            'state' => TransactionState::Paid,
             'date' => fake()->dateTimeBetween('-1 year', 'today')->format('Y-m-d'),
             'expected_payment_date' => null,
             'user_id' => $user->id,
@@ -30,7 +32,7 @@ class TransactionFactory extends Factory
     public function pending(): static
     {
         return $this->state(fn (array $attributes) => [
-            'state' => 'pending',
+            'state' => TransactionState::Pending,
             'expected_payment_date' => fake()->dateTimeBetween('today', '+3 months')->format('Y-m-d'),
         ]);
     }

--- a/resources/views/components/app/modal-grid.blade.php
+++ b/resources/views/components/app/modal-grid.blade.php
@@ -46,8 +46,8 @@
                         <div class="flex flex-col items-start sm:items-center flex-1">
                             <div class="flex items-center w-full sm:w-auto mb-3 sm:mb-0">
                                 <div
-                                    class="rounded-full p-2 mr-3 {{ $transaction->type === 'income' ? 'bg-green-100 dark:bg-green-900/30' : 'bg-red-100 dark:bg-red-900/30' }}">
-                                    @if($transaction->type === 'income')
+                                    class="rounded-full p-2 mr-3 {{ $transaction->isIncome() ? 'bg-green-100 dark:bg-green-900/30' : 'bg-red-100 dark:bg-red-900/30' }}">
+                                    @if($transaction->isIncome())
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor"
                                              viewBox="0 0 24 24"
                                              class="w-5 h-5 text-green-700 dark:text-green-400">
@@ -101,8 +101,8 @@
                         <div
                             class="flex items-center justify-end w-full sm:w-auto gap-3 mt-2 sm:mt-0">
                             <div
-                                class="text-sm sm:text-base font-semibold {{ $transaction->type === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400' }}">
-                                <span>{{ $transaction->type === 'income' ? '+' : '-' }} ${{ number_format($transaction->amount, 2, ',', '.') }}</span>
+                                class="text-sm sm:text-base font-semibold {{ $transaction->isIncome() ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400' }}">
+                                <span>{{ $transaction->isIncome() ? '+' : '-' }} ${{ number_format($transaction->amount, 2, ',', '.') }}</span>
                             </div>
                             <label for="toggle-{{ $transaction->id }}" class="inline-flex items-center gap-3">
                                 <input id="toggle-{{ $transaction->id }}" type="checkbox" class="peer sr-only"

--- a/resources/views/components/app/transaction-list.blade.php
+++ b/resources/views/components/app/transaction-list.blade.php
@@ -8,8 +8,8 @@
         <li class="flex flex-col gap-3 p-3 sm:p-4 rounded-lg bg-surface-alt shadow border dark:border-neutral-700 dark:bg-surface-dark-alt/50 hover:shadow-xs dark:hover:shadow-neutral-600 transition-shadow duration-200">
             <div class="flex items-center w-full sm:w-auto mb-3 sm:mb-0">
                 <div
-                    class="rounded-full p-2 mr-3 {{ $transaction->type === 'income' ? 'bg-green-100 dark:bg-green-900/30' : 'bg-red-100 dark:bg-red-900/30' }}">
-                    @if($transaction->type === 'income')
+                    class="rounded-full p-2 mr-3 {{ $transaction->isIncome() ? 'bg-green-100 dark:bg-green-900/30' : 'bg-red-100 dark:bg-red-900/30' }}">
+                    @if($transaction->isIncome())
                         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"
                              class="w-5 h-5 text-green-700 dark:text-green-400">
                             <path fill-rule="evenodd"
@@ -44,9 +44,9 @@
             </div>
             <div class="flex items-center justify-end w-full sm:w-auto gap-3 mt-2 sm:mt-0">
                 <div
-                    class="text-base sm:text-lg font-semibold {{ $transaction->type === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400' }}">
+                    class="text-base sm:text-lg font-semibold {{ $transaction->isIncome() ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400' }}">
                         <span>
-                            {{ $transaction->type === 'income' ? '+' : '-' }} ${{ number_format($transaction->amount, 2, ',', '.') }}</span>
+                            {{ $transaction->isIncome() ? '+' : '-' }} ${{ number_format($transaction->amount, 2, ',', '.') }}</span>
                 </div>
                 <a href="{{ route('transaction.edit', [$transaction, 'from' => $redirectTo]) }}"
                    wire:navigate

--- a/resources/views/livewire/transactions/pending-transactions.blade.php
+++ b/resources/views/livewire/transactions/pending-transactions.blade.php
@@ -82,8 +82,8 @@
                         {{ $transaction->is_payment_future === false ? 'border-2 border-red-300 dark:border-red-600 animate-pulse' : '' }}">
                         <div class="flex items-center w-full sm:w-auto mb-2 sm:mb-0">
                             <div
-                                class="rounded-full p-2 mr-2 sm:mr-3 {{ $transaction->type === 'income' ? 'bg-green-100 dark:bg-green-900/30' : 'bg-red-100 dark:bg-red-900/30' }}">
-                                @if ($transaction->type === 'income')
+                                class="rounded-full p-2 mr-2 sm:mr-3 {{ $transaction->isIncome() ? 'bg-green-100 dark:bg-green-900/30' : 'bg-red-100 dark:bg-red-900/30' }}">
+                                @if ($transaction->isIncome())
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"
                                          class="w-4 h-4 sm:w-5 sm:h-5 text-green-700 dark:text-green-400">
                                         <path fill-rule="evenodd"
@@ -131,15 +131,15 @@
                                        wire:confirm="Desea marcar como pagada esta transacción?"/>
                                 <span
                                     class="trancking-wide text-sm font-medium text-on-surface peer-checked:text-on-surface-strong peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:text-on-surface-dark dark:peer-checked:text-on-surface-dark-strong">
-                                    {{ $transaction->type === 'income' ? 'Cobrar' : 'Pagar' }}
+                                    {{ $transaction->isIncome() ? 'Cobrar' : 'Pagar' }}
                                 </span>
                                 <div
                                     class="relative h-7 w-12 after:h-6 after:w-6 peer-checked:after:translate-x-5 rounded-full border border-outline bg-surface-alt after:absolute after:bottom-0 after:left-[0.0625rem] after:top-0 after:my-auto after:rounded-full after:bg-on-surface after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:bg-on-primary peer-focus:outline-2 peer-focus:outline-offset-2 peer-focus:outline-outline-strong peer-focus:peer-checked:outline-primary peer-active:outline-offset-0 peer-disabled:cursor-not-allowed peer-disabled:opacity-70 dark:border-outline-dark dark:bg-surface-dark-alt dark:after:bg-on-surface-dark dark:peer-checked:bg-primary-dark dark:peer-checked:after:bg-on-primary-dark dark:peer-focus:outline-outline-dark-strong dark:peer-focus:peer-checked:outline-primary-dark"
                                     aria-hidden="true"></div>
                             </label>
                             <div
-                                class="text-sm sm:text-base font-semibold {{ $transaction->type === 'income' ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400' }}">
-                                <span>{{ $transaction->type === 'income' ? '+' : '-' }}
+                                class="text-sm sm:text-base font-semibold {{ $transaction->isIncome() ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400' }}">
+                                <span>{{ $transaction->isIncome() ? '+' : '-' }}
                                     ${{ number_format($transaction->amount, 2, ',', '.') }}</span>
                             </div>
 

--- a/tests/Feature/Transactions/TransactionValidationTest.php
+++ b/tests/Feature/Transactions/TransactionValidationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Enums\TransactionState;
+use App\Enums\TransactionType;
 use App\Livewire\Transactions\Create;
 use App\Livewire\Transactions\Update;
 use App\Models\Category;
@@ -25,7 +27,7 @@ test('user cannot create a transaction assigned to another user category', funct
         ->assertHasErrors(['form.category_id']);
 
     $this->assertDatabaseMissing('transactions', [
-        'user_id'     => $attacker->id,
+        'user_id' => $attacker->id,
         'category_id' => $otherCategory->id,
     ]);
 });
@@ -47,7 +49,7 @@ test('user cannot update a transaction to use another user category', function (
         ->assertHasErrors(['form.category_id']);
 
     $this->assertDatabaseHas('transactions', [
-        'id'          => $transaction->id,
+        'id' => $transaction->id,
         'category_id' => $attackerCategory->id,
     ]);
 });
@@ -65,8 +67,85 @@ test('marking pending transaction as paid sets expected_payment_date to null', f
         ->call('changeStatus', $transaction->id);
 
     $this->assertDatabaseHas('transactions', [
-        'id'                    => $transaction->id,
-        'state'                 => 'paid',
+        'id' => $transaction->id,
+        'state' => 'paid',
         'expected_payment_date' => null,
     ]);
+});
+
+// --- Enum casts & helpers ---
+
+test('transaction type and state are cast to enum instances on fetch', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    Transaction::create([
+        'type' => TransactionType::Income,
+        'state' => TransactionState::Paid,
+        'amount' => 100,
+        'description' => 'enum round-trip',
+        'date' => now(),
+        'user_id' => $user->id,
+        'category_id' => $category->id,
+    ]);
+
+    $fresh = Transaction::where('description', 'enum round-trip')->first();
+
+    expect($fresh->type)->toBe(TransactionType::Income);
+    expect($fresh->state)->toBe(TransactionState::Paid);
+});
+
+test('query by enum case returns the same rows as query by string value', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->for($category)->count(3)->create();
+    Transaction::factory()->for($user)->for($category)->pending()->count(2)->create();
+
+    $byEnum = Transaction::where('state', TransactionState::Pending)->count();
+    $byString = Transaction::where('state', 'pending')->count();
+
+    expect($byEnum)->toBe(2);
+    expect($byString)->toBe($byEnum);
+});
+
+test('isIncome and isExpense helpers reflect the type enum', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    $income = Transaction::factory()->for($user)->for($category)->create(['type' => TransactionType::Income]);
+    $expense = Transaction::factory()->for($user)->for($category)->create(['type' => TransactionType::Expense]);
+
+    expect($income->isIncome())->toBeTrue();
+    expect($income->isExpense())->toBeFalse();
+    expect($expense->isExpense())->toBeTrue();
+    expect($expense->isIncome())->toBeFalse();
+});
+
+test('isPaid and isPending helpers reflect the state enum', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    $paid = Transaction::factory()->for($user)->for($category)->create();
+    $pending = Transaction::factory()->for($user)->for($category)->pending()->create();
+
+    expect($paid->isPaid())->toBeTrue();
+    expect($paid->isPending())->toBeFalse();
+    expect($pending->isPending())->toBeTrue();
+    expect($pending->isPaid())->toBeFalse();
+});
+
+test('invalid type value fails validation', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.type', 'transfer')
+        ->set('form.amount', 100)
+        ->set('form.description', 'Invalid type test')
+        ->set('form.date', now()->format('Y-m-d'))
+        ->set('form.category_id', $category->id)
+        ->call('save')
+        ->assertHasErrors(['form.type']);
 });


### PR DESCRIPTION
## Summary

Reemplaza los literales stringly-typed `'income'`/`'expense'` y `'paid'`/`'pending'` distribuidos por Livewire components, forms, factories y vistas Blade por backed PHP enums. Las columnas DB siguen siendo `ENUM` strings; los casts del modelo hacen la conversión.

## Cambios

**Nuevo:**
- `app/Enums/TransactionType.php` — cases `Income`, `Expense`.
- `app/Enums/TransactionState.php` — cases `Paid`, `Pending`.
- `Transaction::$casts` mapea `type` y `state`.
- Helpers del modelo: `isIncome()`, `isExpense()`, `isPaid()`, `isPending()` — mantienen Blade libre de imports de enum y centralizan cualquier cambio futuro.

**Actualizado:**
- Validación: `'in:income,expense'` → `Rule::enum(TransactionType::class)`.
- Queries: `where('state', 'paid')` → `where('state', TransactionState::Paid)`.
- Collection filters sobre atributos casteados pasan el enum case (Collection::where usa `===`; string y enum no matchean).
- Blade: `$tx->type === 'income'` → `$tx->isIncome()` en `transaction-list`, `modal-grid`, `pending-transactions`.
- Factory usa enum cases.
- `Transaction::insert` raw en `ObligationForm::createTransactions` usa `->value` porque `insert()` bypasea el cast.

## Test plan

- [x] 5 tests nuevos: round-trip cast, query enum vs string, helpers `isIncome`/`isExpense`/`isPaid`/`isPending`, validación rechaza valor inválido.
- [x] Suite completa: **92/92 passed** (200 assertions).

Corresponde a Fase 2 del roadmap (reordenada delante de Fase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)