### PR TITLE
feat(transactions): add nullable obligation_id FK column

### DIFF
--- a/app/Models/Obligation.php
+++ b/app/Models/Obligation.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Obligation extends Model
 {
@@ -14,12 +15,17 @@ class Obligation extends Model
     protected $fillable = ['name', 'amount', 'description', 'limit_day', 'is_active', 'user_id'];
 
     protected $casts = [
-        'amount'    => 'decimal:2',
+        'amount' => 'decimal:2',
         'is_active' => 'boolean',
     ];
 
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function transactions(): HasMany
+    {
+        return $this->hasMany(Transaction::class);
     }
 }

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -14,7 +14,7 @@ class Transaction extends Model
 {
     use HasFactory, HasUuids, SoftDeletes;
 
-    protected $fillable = ['type', 'amount', 'description', 'state', 'expected_payment_date', 'date', 'user_id', 'category_id'];
+    protected $fillable = ['type', 'amount', 'description', 'state', 'expected_payment_date', 'date', 'user_id', 'category_id', 'obligation_id'];
 
     protected $casts = [
         'amount' => 'decimal:2',
@@ -52,6 +52,11 @@ class Transaction extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(Category::class);
+    }
+
+    public function obligation(): BelongsTo
+    {
+        return $this->belongsTo(Obligation::class);
     }
 
     protected function getFormattedDateAttribute()

--- a/database/migrations/2026_04_23_120000_add_obligation_id_to_transactions.php
+++ b/database/migrations/2026_04_23_120000_add_obligation_id_to_transactions.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+// Adds transactions.obligation_id as a nullable FK to obligations(id).
+// Additive only — historical rows keep NULL. The backfill and wiring to
+// remove the fragile (user_id, description) match happens in a separate
+// migration/PR, so this one can be applied in production without a
+// maintenance window.
+//
+// ON DELETE SET NULL: deleting an obligation leaves its transactions
+// standing (with obligation_id = NULL) so historical data isn't lost.
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('transactions', 'obligation_id')) {
+            return;
+        }
+
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->foreignUuid('obligation_id')
+                ->nullable()
+                ->after('category_id')
+                ->constrained('obligations')
+                ->nullOnDelete();
+
+            $table->index('obligation_id', 'transactions_obligation_id_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $existingIndexes = collect(Schema::getIndexes('transactions'))->pluck('name');
+            $existingFks = collect(Schema::getForeignKeys('transactions'))->pluck('name');
+
+            if ($existingIndexes->contains('transactions_obligation_id_index')) {
+                $table->dropIndex('transactions_obligation_id_index');
+            }
+
+            if ($existingFks->contains('transactions_obligation_id_foreign')) {
+                $table->dropForeign('transactions_obligation_id_foreign');
+            }
+
+            if (Schema::hasColumn('transactions', 'obligation_id')) {
+                $table->dropColumn('obligation_id');
+            }
+        });
+    }
+};

--- a/tests/Feature/Obligations/ObligationTransactionRelationTest.php
+++ b/tests/Feature/Obligations/ObligationTransactionRelationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Obligation;
+use App\Models\Transaction;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+// --- Schema invariants for transactions.obligation_id ---
+// These pin the migration contract: the column exists, is nullable,
+// and its FK behaves as ON DELETE SET NULL (not CASCADE, not RESTRICT).
+
+test('transactions table has nullable obligation_id column', function () {
+    expect(Schema::hasColumn('transactions', 'obligation_id'))->toBeTrue();
+
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create();
+
+    // Historical / freshly-created transactions may have no obligation.
+    expect($transaction->obligation_id)->toBeNull();
+});
+
+test('transaction can be created with an obligation_id and it persists', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+    $obligation = Obligation::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create(['obligation_id' => $obligation->id]);
+
+    $fresh = Transaction::find($transaction->id);
+
+    expect($fresh->obligation_id)->toBe($obligation->id);
+});
+
+// --- ON DELETE SET NULL behavior ---
+// When an obligation is deleted, its transactions must survive with
+// obligation_id = NULL. Historical audit data is preserved.
+
+test('deleting an obligation sets obligation_id to null on its transactions, not deletes them', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+    $obligation = Obligation::factory()->for($user)->create();
+
+    $transaction = Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create(['obligation_id' => $obligation->id]);
+
+    $obligation->delete();
+
+    $fresh = Transaction::find($transaction->id);
+
+    expect($fresh)->not->toBeNull();
+    expect($fresh->obligation_id)->toBeNull();
+});
+
+// --- Bidirectional relationship ---
+
+test('obligation has many transactions relationship works', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+    $obligation = Obligation::factory()->for($user)->create();
+
+    Transaction::factory()->for($user)->for($category)->count(3)->create(['obligation_id' => $obligation->id]);
+    Transaction::factory()->for($user)->for($category)->create(); // unrelated
+
+    expect($obligation->transactions)->toHaveCount(3);
+});
+
+test('transaction belongs to obligation relationship works', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+    $obligation = Obligation::factory()->for($user)->create(['name' => 'Internet']);
+
+    $transaction = Transaction::factory()
+        ->for($user)
+        ->for($category)
+        ->create(['obligation_id' => $obligation->id]);
+
+    expect($transaction->obligation)->not->toBeNull();
+    expect($transaction->obligation->name)->toBe('Internet');
+});


### PR DESCRIPTION
## Summary

Migration **aditiva pura** que introduce `transactions.obligation_id` como FK UUID nullable hacia `obligations(id)`.

- **Sin backfill.** Las filas históricas quedan con `obligation_id = NULL`.
- **Sin wiring de código.** `ObligationForm` sigue matcheando por `description` hasta el PR 1B.
- **Deploy sin ventana de mantenimiento.** No toca datos existentes.

## Decisión clave: `ON DELETE SET NULL`

Al borrar una obligación, las transacciones asociadas sobreviven con `obligation_id = NULL`. Alternativas:
- `RESTRICT` → no se puede borrar una obligación que tuvo transacciones alguna vez. Demasiado estricto.
- `CASCADE` → borra la transacción. Perdemos audit histórico.
- `SET NULL` elegido → la transacción queda huérfana pero presente.

## Cambios

- `database/migrations/2026_04_23_120000_add_obligation_id_to_transactions.php` — aditiva, idempotente, reversible.
- `Transaction::$fillable` incluye `obligation_id`; nueva relación `obligation()`.
- `Obligation` recibe relación `transactions()`.

## Test plan

5 tests nuevos en `ObligationTransactionRelationTest.php`:
- columna existe y default NULL
- asignación round-trip
- `ON DELETE SET NULL` preserva la transacción
- `hasMany` y `belongsTo` funcionan

**Suite:** 97/97 passed (208 assertions).

## Siguiente paso

Después de que apliques esta migration en prod, avanzo con **PR 1B**: backfill de `obligation_id` matcheando por `(user_id, description, category_slug='obligaciones-mensuales')` y refactor de `ObligationForm` para usar la FK en vez del match por string. Ese sí requiere ventana de mantenimiento.

Corresponde a Fase 1 del roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)