### PR TITLE
refactor(livewire): separate compute from effects in render()

### DIFF
--- a/app/Livewire/Metrics/Grid.php
+++ b/app/Livewire/Metrics/Grid.php
@@ -10,14 +10,6 @@ use Livewire\Component;
 
 class Grid extends Component
 {
-    public $total_income;
-
-    public $total_expense;
-
-    public $receivable_transactions;
-
-    public $payable_transactions;
-
     public $modalIsOpen = false;
 
     public $modalType = null;
@@ -52,8 +44,8 @@ class Grid extends Component
             ->orderBy('date')
             ->get();
 
-        $this->receivable_transactions = $allPending->where('type', TransactionType::Income);
-        $this->payable_transactions = $allPending->where('type', TransactionType::Expense);
+        $receivable_transactions = $allPending->where('type', TransactionType::Income);
+        $payable_transactions = $allPending->where('type', TransactionType::Expense);
 
         // Current-month paid totals — single query with conditional aggregation
         // instead of two separate sum() calls.
@@ -67,9 +59,14 @@ class Grid extends Component
             ')
             ->first();
 
-        $this->total_income = $totals->total_income ?? 0;
-        $this->total_expense = $totals->total_expense ?? 0;
+        $total_income = $totals->total_income ?? 0;
+        $total_expense = $totals->total_expense ?? 0;
 
-        return view('livewire.metrics.grid');
+        return view('livewire.metrics.grid', compact(
+            'total_income',
+            'total_expense',
+            'receivable_transactions',
+            'payable_transactions',
+        ));
     }
 }

--- a/app/Livewire/Transactions/Filters.php
+++ b/app/Livewire/Transactions/Filters.php
@@ -26,10 +26,6 @@ class Filters extends Component
 
     public ?string $selectedCategory = null;
 
-    public float $incomes = 0;
-
-    public float $expenses = 0;
-
     public string $showType = 'all';
 
     public string $search = '';
@@ -121,8 +117,8 @@ class Filters extends Component
             ')
             ->first();
 
-        $this->incomes = $totals->total_income ?? 0;
-        $this->expenses = $totals->total_expense ?? 0;
+        $incomes = $totals->total_income ?? 0;
+        $expenses = $totals->total_expense ?? 0;
 
         $transactions = $query
             ->with('category')
@@ -130,6 +126,6 @@ class Filters extends Component
             ->orderBy('updated_at', 'desc')
             ->paginate(12);
 
-        return view('livewire.transactions.filters', compact('transactions'));
+        return view('livewire.transactions.filters', compact('transactions', 'incomes', 'expenses'));
     }
 }

--- a/app/Livewire/Transactions/PendingTransactions.php
+++ b/app/Livewire/Transactions/PendingTransactions.php
@@ -5,17 +5,12 @@ namespace App\Livewire\Transactions;
 use App\Enums\TransactionState;
 use App\Enums\TransactionType;
 use App\Models\Transaction;
-use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
 use Livewire\WithPagination;
 
 class PendingTransactions extends Component
 {
     use WithPagination;
-
-    public Collection $receivables;
-
-    public Collection $payables;
 
     public string $selectedTab = 'all';
 
@@ -54,8 +49,8 @@ class PendingTransactions extends Component
             ->where('state', TransactionState::Pending)
             ->where('date', '<', now()->addMonth()->startOfMonth());
 
-        $this->receivables = (clone $query)->where('type', TransactionType::Income)->get();
-        $this->payables = (clone $query)->where('type', TransactionType::Expense)->get();
+        $receivables = (clone $query)->where('type', TransactionType::Income)->get();
+        $payables = (clone $query)->where('type', TransactionType::Expense)->get();
 
         $query = match ($this->selectedTab) {
             'all' => $query,
@@ -69,6 +64,6 @@ class PendingTransactions extends Component
             ->orderBy('updated_at', 'desc')
             ->paginate(12);
 
-        return view('livewire.transactions.pending-transactions', compact('transactions'));
+        return view('livewire.transactions.pending-transactions', compact('transactions', 'receivables', 'payables'));
     }
 }

--- a/tests/Feature/Metrics/GridTest.php
+++ b/tests/Feature/Metrics/GridTest.php
@@ -57,8 +57,8 @@ test('marking transaction as paid sets expected_payment_date to null', function 
         ->call('changeStatus', $transaction->id);
 
     $this->assertDatabaseHas('transactions', [
-        'id'                    => $transaction->id,
-        'state'                 => 'paid',
+        'id' => $transaction->id,
+        'state' => 'paid',
         'expected_payment_date' => null,
     ]);
 });
@@ -73,25 +73,25 @@ test('grid totals only include the authenticated user transactions', function ()
         ->for($user)
         ->for(Category::factory()->for($user))
         ->create([
-            'type'   => 'income',
+            'type' => 'income',
             'amount' => 1000,
-            'state'  => 'paid',
-            'date'   => now(),
+            'state' => 'paid',
+            'date' => now(),
         ]);
 
     Transaction::factory()
         ->for($otherUser)
         ->for(Category::factory()->for($otherUser))
         ->create([
-            'type'   => 'income',
+            'type' => 'income',
             'amount' => 9999,
-            'state'  => 'paid',
-            'date'   => now(),
+            'state' => 'paid',
+            'date' => now(),
         ]);
 
     $component = Livewire::actingAs($user)->test(Grid::class);
 
-    expect((float) $component->get('total_income'))->toBe(1000.0);
+    expect((float) $component->viewData('total_income'))->toBe(1000.0);
 });
 
 test('grid pending transactions only include the authenticated user transactions', function () {
@@ -112,5 +112,5 @@ test('grid pending transactions only include the authenticated user transactions
 
     $component = Livewire::actingAs($user)->test(Grid::class);
 
-    expect($component->get('payable_transactions'))->toHaveCount(1);
+    expect($component->viewData('payable_transactions'))->toHaveCount(1);
 });

--- a/tests/Feature/Transactions/TransactionFiltersTest.php
+++ b/tests/Feature/Transactions/TransactionFiltersTest.php
@@ -56,8 +56,8 @@ test('fallback on unknown selectedTab preserves tenant isolation', function () {
         ->test(Filters::class)
         ->set('selectedTab', 'foo');
 
-    expect((float) $component->get('incomes'))->toBe(0.0);
-    expect((float) $component->get('expenses'))->toBe(0.0);
+    expect((float) $component->viewData('incomes'))->toBe(0.0);
+    expect((float) $component->viewData('expenses'))->toBe(0.0);
     $component->assertDontSee('secret-of-b');
 });
 
@@ -95,7 +95,7 @@ test('fallback on unknown selectedTab does not broaden scope beyond 7 days', fun
         ->test(Filters::class)
         ->set('selectedTab', 'unknown');
 
-    expect((float) $component->get('incomes'))->toBe(100.0);
+    expect((float) $component->viewData('incomes'))->toBe(100.0);
     $component->assertSee('recent-tx')
         ->assertDontSee('old-tx-outside-window');
 });
@@ -137,7 +137,7 @@ test('clicking the days tab filters the render to the last 7 days', function () 
         ->call('latestDays');
 
     expect($component->get('selectedTab'))->toBe('days');
-    expect((float) $component->get('incomes'))->toBe(100.0);
+    expect((float) $component->viewData('incomes'))->toBe(100.0);
     $component->assertSee('within-7-days-window')
         ->assertDontSee('outside-7-days-window');
 });


### PR DESCRIPTION
## Summary

Livewire anti-pattern corregido en 3 componentes.

**Antes:** `render()` asignaba `\$this->total_income = ...`, `\$this->receivables = ...` etc. Propiedades públicas en Livewire son **estado persistente cliente-side**, no lugar para datos derivados de la DB. Se recomputaban en cada render pero también se serializaban al cliente.

**Después:** variables locales pasadas a la view via `compact()`. `render()` se comporta más cerca de una función pura: toma estado + DB, devuelve view data, sin mutar `\$this`.

## Properties removidas

| Componente | Removidas |
|---|---|
| `Grid` | `total_income`, `total_expense`, `receivable_transactions`, `payable_transactions` |
| `Filters` | `incomes`, `expenses` |
| `PendingTransactions` | `receivables`, `payables` |

Estado real sobrevive intacto: `selectedTab`, `selectedMonth`, `categories`, `modalIsOpen`, `selectedCategory`, `showType`, `search`, etc.

## Test plan

- [x] 6 assertions ajustadas: `\$component->get('X')` → `\$component->viewData('X')`. Mismo contrato semántico, refleja mejor de dónde viene el dato.
- [x] **0 vistas modificadas** — los nombres de variable se mantuvieron (snake_case en las Blade).
- [x] Suite completa: **97/97 passed** (208 assertions).

## Bonus

El payload Livewire del cliente se reduce: antes serializaba 4 colecciones completas en `Grid` y 2 en `PendingTransactions`. Ahora viajan solo el HTML rendered.

Corresponde a Fase 4 del roadmap (FP — B.1: separación compute/efecto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)