### PR TITLE
chore: rename composer identity from starter kit to project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,13 @@
 {
     "$schema": "https://getcomposer.org/schema.json",
-    "name": "laravel/livewire-starter-kit",
+    "name": "jasanzdev/financely",
     "type": "project",
-    "description": "The official Laravel starter kit for Livewire.",
+    "description": "Financely — personal finance tracker built with Laravel and Livewire.",
     "keywords": [
         "laravel",
-        "framework"
+        "livewire",
+        "finance",
+        "pwa"
     ],
     "license": "MIT",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5e8557ea0c1fc2e77cfe80b45b70e6a",
+    "content-hash": "abfc05b63726da5715c6c2d3d9c919c5",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
## Summary

- `composer.json` seguía identificando el proyecto como `laravel/livewire-starter-kit` con descripción y keywords del starter.
- Actualizado a la identidad real:
  - `name`: `jasanzdev/financely`
  - `description`: "Financely — personal finance tracker built with Laravel and Livewire."
  - `keywords`: `laravel`, `livewire`, `finance`, `pwa`
- `composer.lock` regenerado con `composer update --lock` para que el hash matchee.

## Test plan

- [x] `composer validate` → OK.
- [x] Suite: 97/97 passed.

PR 5.1 de 3 de Fase 5 (higiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)