### PR TITLE
refactor: move data loading from mount() to render() in index components

### DIFF
--- a/app/Livewire/Category/CategoryIndex.php
+++ b/app/Livewire/Category/CategoryIndex.php
@@ -3,23 +3,14 @@
 namespace App\Livewire\Category;
 
 use App\Models\Category;
-use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
 
 class CategoryIndex extends Component
 {
-    public Collection|null $categories = null;
-
-    public function mount()
-    {
-        $this->categories = Category::where('user_id', auth()->id())->get();
-    }
-
     public function toggleActive(Category $category)
     {
         $this->authorize('update', $category);
-        $category->update(['is_active' => !$category->is_active]);
-        $this->categories = Category::where('user_id', auth()->id())->get();
+        $category->update(['is_active' => ! $category->is_active]);
     }
 
     public function delete(Category $category)
@@ -29,6 +20,7 @@ class CategoryIndex extends Component
         if ($category->transactions()->exists()) {
             session()->flash('message', 'No se ha podido eliminar la categoría, mueva las transacciones existentes');
             $this->redirect(route('category.index'), navigate: true);
+
             return;
         }
 
@@ -41,6 +33,8 @@ class CategoryIndex extends Component
 
     public function render()
     {
-        return view('livewire.category.category-index');
+        $categories = Category::where('user_id', auth()->id())->get();
+
+        return view('livewire.category.category-index', compact('categories'));
     }
 }

--- a/app/Livewire/Transactions/Index.php
+++ b/app/Livewire/Transactions/Index.php
@@ -8,21 +8,6 @@ use Livewire\Component;
 
 class Index extends Component
 {
-    public $transactions;
-
-    public function mount()
-    {
-        $user = auth()->id();
-        $this->transactions = Transaction::with('category')
-            ->take(8)
-            ->where('user_id', $user)
-            ->where('state', TransactionState::Paid)
-            ->where('date', '>=', now()->startOfMonth())
-            ->where('date', '<', now()->addMonth()->startOfMonth())
-            ->orderBy('date', 'desc')
-            ->get();
-    }
-
     public function delete(Transaction $transaction)
     {
         $this->authorize('delete', $transaction);
@@ -33,6 +18,15 @@ class Index extends Component
 
     public function render()
     {
-        return view('livewire.transactions.index');
+        $transactions = Transaction::with('category')
+            ->where('user_id', auth()->id())
+            ->where('state', TransactionState::Paid)
+            ->where('date', '>=', now()->startOfMonth())
+            ->where('date', '<', now()->addMonth()->startOfMonth())
+            ->orderBy('date', 'desc')
+            ->take(8)
+            ->get();
+
+        return view('livewire.transactions.index', compact('transactions'));
     }
 }

--- a/tests/Feature/Categories/CategoryAuthorizationTest.php
+++ b/tests/Feature/Categories/CategoryAuthorizationTest.php
@@ -108,3 +108,26 @@ test('other user cannot update a category they do not own', function () {
 
     $this->assertDatabaseHas('categories', ['id' => $category->id, 'category' => 'Original Name']);
 });
+
+// --- Staleness regression ---
+// toggleActive used to mutate the DB and then re-query manually to keep the
+// view in sync. If the manual re-query were ever removed — or if a developer
+// added a similar action without remembering it — the view would show the
+// pre-toggle state until reload. Loading in render() makes this automatic.
+
+test('toggling a category active status reflects in the rendered list without manual refetch', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create([
+        'category' => 'ToggleTarget',
+        'is_active' => true,
+    ]);
+
+    $component = Livewire::actingAs($user)->test(CategoryIndex::class);
+
+    $component->call('toggleActive', $category->id)
+        ->assertHasNoErrors();
+
+    $rendered = $component->viewData('categories')->firstWhere('id', $category->id);
+
+    expect($rendered->is_active)->toBeFalse();
+});

--- a/tests/Feature/Categories/CategoryDataIsolationTest.php
+++ b/tests/Feature/Categories/CategoryDataIsolationTest.php
@@ -29,5 +29,5 @@ test('user only sees their own categories count in the index', function () {
 
     $component = Livewire::actingAs($userA)->test(CategoryIndex::class);
 
-    expect($component->get('categories'))->toHaveCount(2);
+    expect($component->viewData('categories'))->toHaveCount(2);
 });

--- a/tests/Feature/Transactions/TransactionAuthorizationTest.php
+++ b/tests/Feature/Transactions/TransactionAuthorizationTest.php
@@ -160,3 +160,32 @@ test('other user cannot delete pending transaction', function () {
 
     $this->assertDatabaseHas('transactions', ['id' => $transaction->id]);
 });
+
+// --- Staleness regression ---
+// After delete, the rendered list must not include the deleted transaction.
+// Previously, Index loaded transactions in mount() and delete() only touched
+// the DB, so the view kept showing stale data until a full page reload.
+
+test('index does not show a transaction after it has been deleted', function () {
+    $user = User::factory()->create();
+    $category = Category::factory()->for($user)->create();
+
+    $kept = Transaction::factory()->for($user)->for($category)->create([
+        'state' => 'paid',
+        'date' => now(),
+        'description' => 'kept-after-delete',
+    ]);
+
+    $removed = Transaction::factory()->for($user)->for($category)->create([
+        'state' => 'paid',
+        'date' => now(),
+        'description' => 'removed-after-delete',
+    ]);
+
+    $component = Livewire::actingAs($user)->test(Index::class);
+
+    $component->call('delete', $removed->id)
+        ->assertHasNoErrors()
+        ->assertSee('kept-after-delete')
+        ->assertDontSee('removed-after-delete');
+});


### PR DESCRIPTION
## Summary

Fix de **bug real de staleness** en `Transactions\Index` + limpieza del workaround que encubría el mismo bug en `Category\CategoryIndex`.

### El bug

- `Index::mount()` cargaba las últimas 8 transacciones pagadas en `\$this->transactions`.
- `Index::delete()` tocaba la DB pero no la propiedad pública.
- Livewire re-renderizaba con la colección vieja. La transacción eliminada seguía visible hasta reload completo.

`CategoryIndex` ocultaba el mismo bug con un refetch manual dentro de `toggleActive()`. La \"protección\" era un workaround, no diseño.

## Fix

Ambos componentes cargan datos dentro de `render()` y los pasan vía `compact()`. `mount()` se elimina donde solo hacía de loader.

**Removido:**
- `Index`: propiedad pública `\$transactions`, `mount()`.
- `CategoryIndex`: propiedad pública `\$categories`, `mount()`, refetch manual dentro de `toggleActive()`.

**Conservado:**
- Redirects en `CategoryIndex::delete` — cumplen un rol UX (limpiar URL después del flash), no solo refresh.

## Test plan

- [x] Test nuevo en `TransactionAuthorizationTest`: eliminar una tx desde Index la saca del rendered output. **Falla pre-fix** (el `assertDontSee('removed-after-delete')` no se cumple porque la collection viva del mount la sigue conteniendo).
- [x] Test nuevo en `CategoryAuthorizationTest`: `toggleActive` se refleja en `viewData('categories')` sin refetch manual.
- [x] Ajuste en `CategoryDataIsolationTest`: `get('categories')` → `viewData('categories')`.
- [x] Suite completa: **99/99 passed** (213 assertions).

PR 5.2 de 3 de Fase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)