### PR TITLE
refactor(obligations): clean up MonthlyBillings::render

### DIFF
--- a/app/Livewire/Obligations/MonthlyBillings.php
+++ b/app/Livewire/Obligations/MonthlyBillings.php
@@ -11,15 +11,11 @@ class MonthlyBillings extends Component
 {
     public ObligationForm $form;
 
-    public $totalObligation = 0;
-
-    public $countObligation = 0;
-
     public $obligationModalIsOpen = false;
 
     public function openModal($obligationId = null)
     {
-        if (!is_null($obligationId)) {
+        if (! is_null($obligationId)) {
             $obligation = Obligation::where('id', $obligationId)
                 ->where('user_id', auth()->id())
                 ->firstOrFail();
@@ -63,10 +59,10 @@ class MonthlyBillings extends Component
             $isActive
                 ? $this->form->removeTransactions($obligation)
                 : $this->form->createTransactions($obligation);
-            $obligation->update(['is_active' => !$isActive]);
+            $obligation->update(['is_active' => ! $isActive]);
         });
 
-        session()->flash('message', 'Se ha ' . ($isActive ? 'desactivado' : 'activado') . ' tu obligación.');
+        session()->flash('message', 'Se ha '.($isActive ? 'desactivado' : 'activado').' tu obligación.');
     }
 
     public function delete(Obligation $obligation)
@@ -80,14 +76,20 @@ class MonthlyBillings extends Component
 
         session()->flash('message', 'Se ha eliminado la obligación y tus cuentas por pagar relacionadas.');
     }
-    
+
     public function render()
     {
         $obligations = Obligation::where('user_id', auth()->id())->get();
 
-        $this->totalObligation = (clone $obligations)->where('is_active', true)->sum('amount');
-        $this->countObligation = count((clone $obligations)->where('is_active', true));
+        // Collection methods return new collections; no clone needed.
+        // Filter once, then reduce to total and count on the same subset.
+        $activeObligations = $obligations->where('is_active', true);
+        $totalObligation = $activeObligations->sum('amount');
+        $countObligation = $activeObligations->count();
 
-        return view('livewire.obligations.monthly-billings', compact('obligations'));
+        return view(
+            'livewire.obligations.monthly-billings',
+            compact('obligations', 'totalObligation', 'countObligation'),
+        );
     }
 }


### PR DESCRIPTION
## Summary

Tres fixes chicos en un mismo `render()`:

1. **Remover `clone` innecesario sobre `Collection`**. `\$obligations` es una `Illuminate\Support\Collection` (resultado de `->get()`). Sus métodos `where()` devuelven una nueva Collection sin mutar — el `clone` era ruido que sugería una confusión entre Builder y Collection.
2. **Filter once, reduce twice.** Antes `sum('amount')` y `count()` re-filtraban la colección cada uno. Ahora el subset activo se computa una sola vez.
3. **Remover las propiedades públicas derivadas** `\$totalObligation` y `\$countObligation`. Mismo anti-pattern que arreglamos en `Grid`, `Filters` y `PendingTransactions`. Pasan vía `compact()` a la view.

## Test plan

- [x] Sin cambios en la view — las variables Blade consumían `\$totalObligation`/`\$countObligation`, no `\$this->...`.
- [x] Suite: **99/99 passed** (213 assertions). Sin cambio de comportamiento.

Cierra Fase 5 (higiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)